### PR TITLE
Add JSON parsing helper and tests

### DIFF
--- a/app/processing/openai_agent.py
+++ b/app/processing/openai_agent.py
@@ -13,6 +13,16 @@ PROMPT_PATH = Path(__file__).with_name("gpt4o_prompt.json")
 with open(PROMPT_PATH, "r", encoding="utf-8") as f:
     PROMPT = json.load(f)["prompt"]
 
+
+def parse_json_from_response(text: str) -> dict:
+    """Parse a JSON string that may be wrapped in triple backtick fences."""
+    cleaned = text.strip()
+    if cleaned.startswith("```") and cleaned.endswith("```"):
+        cleaned = cleaned[3:-3].strip()
+        if cleaned.lower().startswith("json"):
+            cleaned = cleaned[4:].lstrip()
+    return json.loads(cleaned)
+
 def pdf_to_b64_images(pdf_bytes: bytes, max_dim_px: int = 2200, jpeg_q: int = 80) -> list[str]:
     """Render each PDF page to base64-encoded JPEG."""
     doc = fitz.open(stream=pdf_bytes, filetype="pdf")
@@ -107,7 +117,7 @@ def extract(file_bytes: bytes, email_body: str, file_extension: str = ".pdf"):
                 raise ValueError("OpenAI returned empty response")
                 
             print(f"🔧 DEBUG: Attempting to parse JSON...")
-            parsed_data = json.loads(content)
+            parsed_data = parse_json_from_response(content)
             print(f"🔧 DEBUG: JSON parsing successful")
             print(f"🔧 DEBUG: Parsed data keys: {list(parsed_data.keys()) if isinstance(parsed_data, dict) else 'Not a dict'}")
             return parsed_data

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/test_openai_agent.py
+++ b/tests/test_openai_agent.py
@@ -1,0 +1,32 @@
+import sys
+import types
+from pathlib import Path
+
+# Ensure repository root is on the import path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+# Create a minimal stub for the openai package so that importing the agent does
+# not fail in environments without the dependency installed.
+sys.modules.setdefault('openai', types.ModuleType('openai'))
+sys.modules.setdefault('fitz', types.ModuleType('fitz'))
+dotenv_stub = types.ModuleType('dotenv')
+dotenv_stub.load_dotenv = lambda *a, **k: None
+sys.modules.setdefault('dotenv', dotenv_stub)
+
+from app.processing.openai_agent import parse_json_from_response
+
+
+def test_parse_unfenced_json():
+    text = '{"a": 1, "b": "c"}'
+    assert parse_json_from_response(text) == {"a": 1, "b": "c"}
+
+
+def test_parse_fenced_json():
+    text = """```json
+{
+  "a": 1,
+  "b": "c"
+}
+```"""
+    assert parse_json_from_response(text) == {"a": 1, "b": "c"}
+
+


### PR DESCRIPTION
## Summary
- add `parse_json_from_response` helper to clean fenced JSON
- use helper in the OpenAI extraction pipeline
- add unit tests for fenced/unfenced parsing
- configure pytest to only run our tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ffbd1ba5c8321b0670cf78605f600