### PR TITLE
Improve referral detail page layout

### DIFF
--- a/app/crm/referrals/templates/referrals/base.html
+++ b/app/crm/referrals/templates/referrals/base.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <title>Intake CRM</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
 </head>
 <body>
     <h1>Intake CRM</h1>

--- a/app/crm/referrals/templates/referrals/referral_detail.html
+++ b/app/crm/referrals/templates/referrals/referral_detail.html
@@ -1,10 +1,48 @@
 {% extends 'referrals/base.html' %}
 {% block content %}
 <h2>Referral {{ referral.pk }}</h2>
+
 <form method="post">
   {% csrf_token %}
-  {{ form.as_p }}
-  <button type="submit">Save</button>
+  <button type="submit" class="btn btn-primary mb-3">Save</button>
+
+  <div class="mb-3">
+    <label for="{{ form.email_id.id_for_label }}" class="form-label">{{ form.email_id.label }}</label>
+    {{ form.email_id.as_widget(attrs={'class': 'form-control'}) }}
+  </div>
+
+  <div class="mb-3">
+    <label for="{{ form.raw_s3_key.id_for_label }}" class="form-label">{{ form.raw_s3_key.label }}</label>
+    {{ form.raw_s3_key.as_widget(attrs={'class': 'form-control'}) }}
+  </div>
+
+  <div class="mb-3">
+    <label for="{{ form.extracted_json.id_for_label }}" class="form-label">{{ form.extracted_json.label }}</label>
+    {{ form.extracted_json.as_widget(attrs={'class': 'form-control', 'rows': 6}) }}
+  </div>
+
+  <div class="mb-3">
+    <label for="{{ form.corrected_json.id_for_label }}" class="form-label">{{ form.corrected_json.label }}</label>
+    {{ form.corrected_json.as_widget(attrs={'class': 'form-control', 'rows': 6}) }}
+  </div>
+
+  <div class="form-check mb-3">
+    {{ form.processed.as_widget(attrs={'class': 'form-check-input'}) }}
+    <label for="{{ form.processed.id_for_label }}" class="form-check-label">{{ form.processed.label }}</label>
+  </div>
+
+  <div class="mb-3">
+    <label for="{{ form.latitude.id_for_label }}" class="form-label">{{ form.latitude.label }}</label>
+    {{ form.latitude.as_widget(attrs={'class': 'form-control'}) }}
+  </div>
+
+  <div class="mb-3">
+    <label for="{{ form.longitude.id_for_label }}" class="form-label">{{ form.longitude.label }}</label>
+    {{ form.longitude.as_widget(attrs={'class': 'form-control'}) }}
+  </div>
+
+  <button type="submit" class="btn btn-primary">Save</button>
 </form>
-<p><a href="{% url 'provider_selection' referral.pk %}">Choose Provider</a></p>
+
+<p class="mt-3"><a href="{% url 'provider_selection' referral.pk %}">Choose Provider</a></p>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add Bootstrap styling to base template
- convert referral detail view to use Bootstrap form layout
- expand JSON fields to textareas

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68616b4eedf48321ab91ad7609b03309